### PR TITLE
Add simple window module and appendChild.

### DIFF
--- a/src/reasonJs.re
+++ b/src/reasonJs.re
@@ -1,3 +1,12 @@
+module Window = {
+  type t;
+  external window : t = "window" [@@bs.val];
+  external innerWidth : t => int = "innerWidth" [@@bs.get];
+  external innerHeight : t => int = "innerHeight" [@@bs.get];
+  external addEventListener : t => string => (unit => unit) => unit = "addEventListener" [@@bs.send];
+  external onLoad : t => (unit => unit) => unit = "onload" [@@bs.set];
+};
+
 module Date = {
   type t;
   external make : unit => t = "Date" [@@bs.new];
@@ -15,6 +24,7 @@ module Math = {
 module Document = {
   type element;
   external getElementById : string => element = "document.getElementById" [@@bs.val];
+  external appendChild : element => 'element => unit = "appendChild" [@@bs.send];
 };
 
 type intervalId;
@@ -50,3 +60,4 @@ module SessionStorage = {
   external key : int => 'a = "sessionStorage.key" [@@bs.val];
   let length () :int => [%bs.raw {|sessionStorage.length|}];
 };
+

--- a/tests/test.re
+++ b/tests/test.re
@@ -1,3 +1,14 @@
-let date = ReasonJs.Date.now ();
+open ReasonJs;
 
-let myInterval = ReasonJs.setInterval (fun () => ReasonJs.Console.log "hello!") 1000;
+let date = Date.now ();
+
+let myInterval = setInterval (fun () => Console.log "hello!") 1000;
+
+let width = Window.(innerWidth window);
+
+let heigth = Window.(innerHeight window);
+
+Window.(addEventListener window "click" (fun () => print_endline "asd"));
+
+Window.(onLoad window (fun () => print_endline "load"));
+


### PR DESCRIPTION
The output of this is fully inlined and clean.

We should consider removing the Math module because Math.random () is
the same as Random.float 1.0; in Reason. Unless clean output really
matters for this. Random.float uses its own implementation here
https://github.com/bloomberg/bucklescript/blob/9d0748f6eb9ef798fc6d4859502843d927683868/lib/js/random.js#L168